### PR TITLE
회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/memo/user/controller/DeleteUserController.java
+++ b/src/main/java/com/memo/user/controller/DeleteUserController.java
@@ -1,0 +1,31 @@
+package com.memo.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.memo.common.security.CustomUserDetails;
+import com.memo.user.entity.User;
+import com.memo.user.service.UserService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteUserController {
+
+	private final UserService userService;
+
+	@DeleteMapping("/api/users")
+	public void deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request, HttpServletResponse response) {
+		//카카오 로그인 사용자인지 확인) {
+		//토큰 삭제, 유저 soft delete, 카카오 로그인 사용자인지 확인, 카카오면
+		User user = userDetails.getUser();
+		userService.deleteUser(user, request, response);
+	}
+
+}

--- a/src/main/java/com/memo/user/oauth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/memo/user/oauth/kakao/KakaoApiClient.java
@@ -131,7 +131,7 @@ public class KakaoApiClient {
 		return response.getBody();
 	}
 
-	public void logout(String token, String blackListToken, User user) {
+	public void logout(String blackListToken) {
 		// int status = validateToken(token);
 		// if (status == 401) {
 		// 	String refreshToken = user.getRefreshToken();

--- a/src/main/java/com/memo/user/oauth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/memo/user/oauth/kakao/KakaoApiClient.java
@@ -118,26 +118,29 @@ public class KakaoApiClient {
 		return response.getBody();
 	}
 
-	public void logout(String token, User user) {
+	public void logout(User user) {
+		String accessToken = tokenRepository.findByKey("kakaoAccess;id" + user.getId());
 		String logout = "https://kapi.kakao.com/v1/user/logout";
-		int status = validateToken(token);
+		int status = validateToken(accessToken);
 		if (status == 401) {
 			String refreshToken = tokenRepository.findByKey("kakaoRefresh;id"+user.getId());
 
 			KakaoTokenResponse response = requestAccessTokenWithRefreshToken(refreshToken);
-			token = response.getAccessToken();
+			accessToken = response.getAccessToken();
 		}
 
 		HttpHeaders header = new HttpHeaders();
-		header.setBearerAuth(token);
+		header.setBearerAuth(accessToken);
 		header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
 		HttpEntity<?> requestLogout = new HttpEntity<>(header);
 
-		header.set("Authorization", "Bearer " + token);
+		header.set("Authorization", "Bearer " + accessToken);
 		ResponseEntity<KakaoTokenInfo> response = restTemplate.postForEntity(logout, requestLogout, KakaoTokenInfo.class);
 
 		log.info(response.toString());
+		tokenRepository.deleteByKey("kakaoAccess;id" + user.getId());
+		tokenRepository.deleteByKey("kakaoRefresh;id" + user.getId());
 
 		}
 

--- a/src/main/java/com/memo/user/repository/UserRepository.java
+++ b/src/main/java/com/memo/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.memo.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.memo.user.entity.User;
@@ -14,4 +16,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByProviderId(String providerId);
 	User findByEmailEquals(String email); //회원가입 시 중복체크, null이면 회원가입 진행
 	User findByUsernameEquals(String username);
+
+	//네이티브 쿼리로 update하는거랑 더티체킹이랑 뭔차이?  -> 영속성 관리
+	@Modifying
+	@Query("update User u set u.isDeleted = true where u.id = :id")
+	void softDeleteById(Long id);
 }

--- a/src/main/java/com/memo/user/service/UserService.java
+++ b/src/main/java/com/memo/user/service/UserService.java
@@ -187,15 +187,15 @@ public class UserService {
 		String jwt = TokenProvider.resolveToken(token);
 		switch (user.getLoginType()) {
 			case KAKAO -> kakaoApiClient.logout(jwt); //카카오 르그아웃에서 쿠키 삭제, 블랙리스트 등록, 리스레시 토큰 삭제 진행하고 있음
-			case NATIVE -> deleteUserById(user.getId(), jwt, response);
+			case NATIVE -> deleteTokenById(user.getId(), jwt, response);
 		}
-
+		userRepository.softDeleteById(user.getId());
 	}
 
-	private void deleteUserById(Long id, String jwt, HttpServletResponse response) {
+	private void deleteTokenById(Long id, String jwt, HttpServletResponse response) {
 		//delete(Entity)와 deleteById(Long) 차이
 		// userRepository.deleteById(id);
-		userRepository.softDeleteById(id);
+
 		//블랙리스트에 추가,토큰 비우기, 쿠키
 		tokenBlackListStore.save(new TokenBlackList(jwt));
 		deleteCookie(response);


### PR DESCRIPTION
## 연관된 이슈
#18 
## 작업 내용
카카오 로그인 유저, 자체 서비스 로그인 유저 구분해서 회원탈퇴
- 카카오 로그인 유저는 로그아웃과 동일한 로직 + 유저 소프트 딜리트
- 서비스 로그인 유저는 토큰 블랙리스트에 추가 , 리프레시 토큰 삭제, 쿠키 삭제
로그아웃만 블랙리스트에 넣는건줄 알았는데 회원탈퇴에서도 넣어주어야함.